### PR TITLE
Fix template on admin groups page

### DIFF
--- a/ESSArch_TP/config/settings.py
+++ b/ESSArch_TP/config/settings.py
@@ -119,6 +119,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'rest_framework.authtoken',
     'corsheaders',
+    'mptt',
     'frontend',
     'ESSArch_Core.admin',
     'ESSArch_Core.auth',


### PR DESCRIPTION
The admin page for groups uses a MPTT template to render the tree