### PR TITLE
Remove usage of Exception.message

### DIFF
--- a/ESSArch_TP/profiles/views.py
+++ b/ESSArch_TP/profiles/views.py
@@ -166,7 +166,7 @@ class ProfileViewSet(ProfileViewSetCore):
                     structure=new_structure,
                 )
             except ValidationError as e:
-                return Response(e.message, status=status.HTTP_400_BAD_REQUEST)
+                raise exceptions.ParseError(e)
 
             serializer = ProfileSerializer(
                 new_profile, context={'request': request}


### PR DESCRIPTION
The message attribute of exceptions was removed in Python 3