### PR TITLE
Use built-in mock

### DIFF
--- a/ESSArch_TP/ip/tests/test_ips.py
+++ b/ESSArch_TP/ip/tests/test_ips.py
@@ -33,7 +33,7 @@ from django.db.models import F
 from django.test import TestCase
 from django.urls import reverse
 
-import unittest.mock
+from unittest import mock
 
 from rest_framework import status
 from rest_framework.test import APIClient

--- a/ESSArch_TP/ip/tests/test_ips.py
+++ b/ESSArch_TP/ip/tests/test_ips.py
@@ -33,7 +33,7 @@ from django.db.models import F
 from django.test import TestCase
 from django.urls import reverse
 
-import mock
+import unittest.mock
 
 from rest_framework import status
 from rest_framework.test import APIClient


### PR DESCRIPTION
`mock` is built-in to Python since 3.3: https://docs.python.org/3/whatsnew/3.3.html