### PR TITLE
Replace super(ClassName, self) with super()

### DIFF
--- a/ESSArch_TP/ip/serializers.py
+++ b/ESSArch_TP/ip/serializers.py
@@ -42,7 +42,7 @@ class InformationPackageSerializer(CoreInformationPackageSerializer):
 
 class InformationPackageReadSerializer(InformationPackageSerializer):
     def to_representation(self, obj):
-        data = super(InformationPackageReadSerializer, self).to_representation(obj)
+        data = super().to_representation(obj)
         profiles = data['profiles']
         data['profiles'] = {}
 

--- a/ESSArch_TP/ip/views.py
+++ b/ESSArch_TP/ip/views.py
@@ -160,7 +160,7 @@ class InformationPackageViewSet(InformationPackageViewSetCore, GetObjectForUpdat
             if ip.submission_agreement_locked:
                 return Response("SA connected to IP is locked", status=status.HTTP_400_BAD_REQUEST)
 
-        return super(InformationPackageViewSet, self).update(request, *args, **kwargs)
+        return super().update(request, *args, **kwargs)
 
     @transaction.atomic
     def destroy(self, request, *args, **kwargs):


### PR DESCRIPTION
`super` in Python 3 requires no arguments, see [release notes](https://docs.python.org/3.0/whatsnew/3.0.html#builtins) and [PEP 3135](https://www.python.org/dev/peps/pep-3135/)