### PR TITLE
Replace REDIS_CLIENT_CLASS with CLIENT_CLASS

### DIFF
--- a/ESSArch_TP/config/settings.py
+++ b/ESSArch_TP/config/settings.py
@@ -230,7 +230,7 @@ CACHES = {
         'BACKEND': 'django_redis.cache.RedisCache',
         'LOCATION': REDIS_URL,
         'OPTIONS': {
-            'REDIS_CLIENT_CLASS': REDIS_CLIENT_CLASS,
+            'CLIENT_CLASS': REDIS_CLIENT_CLASS,
         }
     }
 }


### PR DESCRIPTION
The difference between the two are badly documented but CLIENT_CLASS works where REDIS_CLIENT_CLASS doesn't