### PR TITLE
Fix user deletion

### DIFF
--- a/ESSArch_TP/config/settings.py
+++ b/ESSArch_TP/config/settings.py
@@ -110,6 +110,7 @@ PROXY_PAGINATION_MAPPING = {'none': 'ESSArch_Core.pagination.NoPagination'}
 INSTALLED_APPS = [
     'allauth',
     'allauth.account',
+    'allauth.socialaccount',
     'channels',
     'django.contrib.auth',
     'django.contrib.contenttypes',


### PR DESCRIPTION
`allauth.socialaccount` is required by `django-allauth` to be in `INSTALLED_APPS`, see https://github.com/Tivix/django-rest-auth/issues/412