### PR TITLE
Fix upload file table overflow

### DIFF
--- a/ESSArch_TP/frontend/static/frontend/views/file_upload.html
+++ b/ESSArch_TP/frontend/static/frontend/views/file_upload.html
@@ -53,7 +53,7 @@
         >
         {{'UPLOAD.UPLOADED' | translate}}: {{$flow.sizeUploaded() | filesize}} / {{$flow.getSize() | filesize}}
       </p>
-      <div style="height:359px">
+      <div style="min-height:359px">
         <table class="table table-hover table-bordered table-striped">
           <thead>
             <tr>


### PR DESCRIPTION
When uploading many files at the same time so that the height of the table exceeds its static height, the table overflows its container